### PR TITLE
feat(nut): add buf.wordcount

### DIFF
--- a/lua/nougat/nut/buf/wordcount.lua
+++ b/lua/nougat/nut/buf/wordcount.lua
@@ -1,0 +1,69 @@
+local Item = require("nougat.item")
+local create_cache_store = require("nougat.cache").create_store
+
+local cache_store = create_cache_store("buf", "nut.buf.wordcount", {
+  -- buffer changedtick
+  ct = -1,
+  --- value
+  v = -1,
+})
+
+local function get_wordcount(format)
+  local wordcount = vim.fn.wordcount()
+  local count = wordcount.visual_words or wordcount.words
+  return format(count)
+end
+
+local function default_format(count)
+  return string.format("%d %s", count, count > 1 and " Words" or " Word")
+end
+
+local in_visual_mode = {
+  ["v"] = true,
+  ["vs"] = true,
+  ["V"] = true,
+  ["Vs"] = true,
+  [""] = true,
+  ["s"] = true,
+}
+
+local function get_content(item, ctx)
+  if in_visual_mode[vim.fn.mode()] then
+    return get_wordcount(item.config.format)
+  end
+
+  local cache = item.cache[ctx.bufnr]
+
+  local changedtick = vim.b[ctx.bufnr].changedtick
+  if cache.ct ~= changedtick then
+    cache.ct = changedtick
+    cache.v = get_wordcount(item.config.format)
+  end
+
+  return cache.v
+end
+
+local mod = {}
+
+function mod.create(opts)
+  local item = Item({
+    hidden = opts.hidden,
+    hl = opts.hl,
+    sep_left = opts.sep_left,
+    prefix = opts.prefix,
+    suffix = opts.suffix,
+    sep_right = opts.sep_right,
+  })
+
+  item.cache = cache_store
+
+  item.config = vim.tbl_extend("force", {
+    format = default_format,
+  }, opts.config or {})
+
+  item.content = get_content
+
+  return item
+end
+
+return mod


### PR DESCRIPTION
```lua
local nut = {
  buf = {
    wordcount = require("nougat.nut.buf.wordcount").create,
  },
}

local wordcount_enabled = {
  markdown = true,
}

statusline:add_item(nut.buf.wordcount({
  hidden = function(_, ctx)
    return not wordcount_enabled[vim.bo[ctx.bufnr].filetype]
  end,
  hl = { bg = "darksalmon", fg = "bg" },
  prefix = " ",
  suffix = " ",
  sep_right = sep.right_chevron_solid(true),
  config = {
    format = function(count)
      return string.format("%d %s", count, count > 1 and " Words" or " Word")
    end,
  },
}))
```

![Peek 2022-10-28 20-30](https://user-images.githubusercontent.com/8050659/198646650-b34ea94e-ae74-4eee-9339-bb698371eaa4.gif)
