### PR TITLE
feat(nut): add buf.fileformat

### DIFF
--- a/lua/nougat/nut/buf/fileformat.lua
+++ b/lua/nougat/nut/buf/fileformat.lua
@@ -1,0 +1,29 @@
+local Item = require("nougat.item")
+
+local function get_content(item, ctx)
+  local fileformat = vim.bo[ctx.bufnr].fileformat
+  return item.config.text[fileformat] or fileformat
+end
+
+local mod = {}
+
+function mod.create(opts)
+  local item = Item({
+    hidden = opts.hidden,
+    hl = opts.hl,
+    sep_left = opts.sep_left,
+    prefix = opts.prefix,
+    suffix = opts.suffix,
+    sep_right = opts.sep_right,
+  })
+
+  item.config = vim.tbl_extend("force", {
+    text = {},
+  }, opts.config or {})
+
+  item.content = get_content
+
+  return item
+end
+
+return mod


### PR DESCRIPTION
```lua
local nut = {
  buf = {
    fileformat = require("nougat.nut.buf.fileformat").create,
  },
}

statusline:add_item(nut.buf.fileformat({
  hl = { bg = "gray", fg = "black" },
  sep_left = sep.left_chevron_solid(true),
  prefix = " ",
  suffix = " ",
  config = {
    text = {
      dos = "",
      unix = "",
      mac = "",
    },
  },
}))
```

![image](https://user-images.githubusercontent.com/8050659/198822776-950dfc00-99eb-4446-9325-d323aa53ca4b.png)
